### PR TITLE
Fix anagram tests by avoiding OkObjectResult

### DIFF
--- a/TestProject/AnagramTests.cs
+++ b/TestProject/AnagramTests.cs
@@ -9,26 +9,25 @@ public class AnagramTests
 
     [Fact]
     public void AreAnagramsReturnsTrueIfAnagram() =>
-        Assert.True(_anagramController.AreAnagrams("dusty", "study").Value);
+        Assert.True(_anagramController.AreAnagrams("dusty", "study"));
 
     [Fact]
     public void AreAnagramsReturnsFalseIfNotAnagram() =>
-        Assert.False(_anagramController.AreAnagrams("apple", "banana").Value);
+        Assert.False(_anagramController.AreAnagrams("apple", "banana"));
 
     [Fact]
     public void AreAnagramsReturnsTrueIfIdentical() =>
-        Assert.True(_anagramController.AreAnagrams("apple", "apple").Value);
+        Assert.True(_anagramController.AreAnagrams("apple", "apple"));
 
     [Fact]
     public void AreAnagramsReturnsFalseIfOnlySimilarCharacters() =>
-        Assert.False(_anagramController.AreAnagrams("elephant", "elaphant").Value);
+        Assert.False(_anagramController.AreAnagrams("elephant", "elaphant"));
 
     [Fact]
     public void AreAnagramsReturnsFalseIfOnlyOneCharacters() =>
-        Assert.False(_anagramController.AreAnagrams("eeeeeeee", "elephant").Value);
+        Assert.False(_anagramController.AreAnagrams("eeeeeeee", "elephant"));
 
     [Fact]
     public void AreAnagramsReturnsTrueIfAnagramWithSpaces() =>
-        Assert.True(_anagramController.AreAnagrams("the morse code", "here come dots").Value);
-
+        Assert.True(_anagramController.AreAnagrams("the morse code", "here come dots"));
 }

--- a/src/Pingvinas.Event.Api/Controllers/AnagramController.cs
+++ b/src/Pingvinas.Event.Api/Controllers/AnagramController.cs
@@ -8,10 +8,10 @@ public class AnagramController : ControllerBase
 {
     [HttpGet($"{nameof(AreAnagrams)}")]
     [ProducesResponseType(typeof(bool), 200)]
-    public ActionResult<bool> AreAnagrams(string word, string potentialAnagram)
+    public bool AreAnagrams(string word, string potentialAnagram)
     {
         // TODO: Eirik says this is not correct, whattodo?
         bool result = word == potentialAnagram;
-        return Ok(result);
+        return result;
     }
 }


### PR DESCRIPTION
The tests would not pass regardless of whether the candidate implemented the method correctly. When we are returning an `OkObjectResult` we must unwrap it in the tests to get the expected result like this:

```cs
var response = _anagramController.AreAnagrams("t", "t");

var okResult = Assert.IsType<OkObjectResult>(response.Result);
Assert.NotNull(okResult?.Value);
bool result = Assert.IsType<bool>(okResult.Value);
Assert.True(result);
```

However, we only return the boolean value from the controller. Vi never return any other `IActionResult`, so we can just return the value directly. Any calls to the API will still get 200 OK, but the tests are much simpler.